### PR TITLE
Fix task assignment algorithm and improve reminder messages

### DIFF
--- a/functions/database/migration.ts
+++ b/functions/database/migration.ts
@@ -179,6 +179,18 @@ const HoneydewVersion7 = {
     }
 }
 
+const HoneydewVersion8 = {
+    async up(db: Kysely<any>): Promise<void> {
+        {
+            const table_name = "CHORES"
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('lastDoneBy', "varchar(40)", (col)=>col.defaultTo(null)) // tracks who last completed the chore
+                .execute()
+        }
+    }
+}
+
 export const HoneydewMigrations: Migration[] = [
     HoneydewVersion1,
     HoneydewVersion2,
@@ -186,6 +198,7 @@ export const HoneydewMigrations: Migration[] = [
     HoneydewVersion4,
     HoneydewVersion5,
     HoneydewVersion6,
-    HoneydewVersion7
+    HoneydewVersion7,
+    HoneydewVersion8
 ]
 export const LatestHoneydewDBVersion = HoneydewMigrations.length;

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -221,8 +221,9 @@ export const DbChoreZRaw = z.object({
     frequency: z.number().positive(),
     lastDone: z.number().nonnegative(),  // stored as julian day numbers
     waitUntil: z.number().nonnegative().nullable(), // stored as julian day numbers
-    doneBy: UserIdZ.nullable(), // the last user to do it
+    doneBy: UserIdZ.nullable(), // the user assigned to always do this chore
     lastTimeAssigned: z.number().nonnegative().nullable(), // julian day when it was last assigned
+    lastDoneBy: UserIdZ.nullable(), // the user who last completed this chore
 });
 export const DbChoreZ = DbChoreZRaw.brand<"Chore">();
 export type DbChoreRaw = z.infer<typeof DbChoreZRaw>;


### PR DESCRIPTION
- Cap assignment penalty at 2 to prevent it from dominating cycle scores
  (previously could reach 10 for recently assigned chores)
- Add lastDoneBy field to track who last completed each chore
- Update ChoreComplete to set lastDoneBy when completing
- Update assignment message to include when chore was last done and by whom
- Update reminder message with chore name, days since last done, and completer

https://claude.ai/code/session_01GHdriN8mWw8WQHyHhq3JXT