### PR TITLE
Add individual outfit reminder preferences per user

### DIFF
--- a/functions/api/routers/me.ts
+++ b/functions/api/routers/me.ts
@@ -4,6 +4,18 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { AuthCheck, AuthCheckZ } from '../../auth/auth_types';
 const Router = router({
+  setOutfitReminders: protectedProcedure.input(z.boolean()).query(async (ctx) => {
+    if (ctx.ctx.data.user == null) {
+      throw new TRPCError({
+        code: "UNAUTHORIZED",
+        cause: "User was not found"
+      })
+    }
+    const user = ctx.ctx.data.user;
+    const db = ctx.ctx.data.db;
+    const result = await db.UserSetOutfitReminders(user.id, ctx.input);
+    return result;
+  }),
   magic_link: protectedProcedure.query(async (ctx)=> {
     if (ctx.ctx.data.user == null) {
       throw new TRPCError({
@@ -53,6 +65,7 @@ const Router = router({
       id: user.id,
       color: user.color,
       household,
+      outfit_reminders: user.outfit_reminders,
     };
     return AuthCheckZ.parse(result);
   }),

--- a/functions/auth/auth_types.ts
+++ b/functions/auth/auth_types.ts
@@ -27,6 +27,7 @@ export const AuthCheckZ = z.object({
     task: z.any(),
     color: z.string().min(7),
     icon: z.string(),
+    outfit_reminders: z.number().nonnegative(),
 }).strict()
 export type AuthCheck = z.infer<typeof AuthCheckZ>;
 

--- a/functions/database/migration.ts
+++ b/functions/database/migration.ts
@@ -233,6 +233,18 @@ const HoneydewVersion10 = {
     }
 }
 
+const HoneydewVersion11 = {
+    async up(db: Kysely<any>): Promise<void> {
+        {
+            const table_name = "USERS"
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('outfit_reminders', "integer", (col)=>col.defaultTo(1).notNull()) // 1 = opted in, 0 = opted out
+                .execute()
+        }
+    }
+}
+
 export const HoneydewMigrations: Migration[] = [
     HoneydewVersion1,
     HoneydewVersion2,
@@ -243,6 +255,7 @@ export const HoneydewMigrations: Migration[] = [
     HoneydewVersion7,
     HoneydewVersion8,
     HoneydewVersion9,
-    HoneydewVersion10
+    HoneydewVersion10,
+    HoneydewVersion11
 ]
 export const LatestHoneydewDBVersion = HoneydewMigrations.length;

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -123,6 +123,7 @@ export const DbUserZRaw = z.object({
     _chat_id: z.number().nullable(),
     last_active_date: z.number().nullable(), // Julian day number of last chore completion
     current_streak: z.number().nonnegative(), // Current consecutive days streak
+    outfit_reminders: z.number().nonnegative(), // 1 = opted in, 0 = opted out of outfit reminders
 })
 export const DbUserZ = DbUserZRaw.brand<"User">()
 export type DbUser = z.infer<typeof DbUserZ>;

--- a/functions/triggers/schedule/outfits.ts
+++ b/functions/triggers/schedule/outfits.ts
@@ -6,7 +6,7 @@ export const TriggerOutfits = async function (db: Database, hour: number) {
 
     const message = "Clothing choices under construction";
     const promises = households.map(async (house_id) => {
-        await db.HouseholdTelegramMessageAllMembers(house_id, message);
+        await db.HouseholdTelegramMessageOutfitMembers(house_id, message);
         await db.HouseOutfitMarkComplete(house_id);
         return house_id;
     });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -263,6 +263,21 @@ export const useUserStore = defineStore("user", {
                 return handleError(err);
             }
         },
+        async SetOutfitReminders(enabled: boolean) {
+            try {
+                const result = await client.me.setOutfitReminders.query(enabled);
+                if (this._user != null) {
+                    this._user.outfit_reminders = enabled ? 1 : 0;
+                }
+                return {
+                    success: true,
+                    data: result
+                }
+            }
+            catch (err) {
+                return handleError(err);
+            }
+        },
         async HouseholdSetOutfitHour(hour: number | null) {
             try {
                 const result = await client.household.setOutfitHour.query(hour);

--- a/src/views/HouseholdView.vue
+++ b/src/views/HouseholdView.vue
@@ -55,10 +55,15 @@
             <button class="button is-round" @click="setAutoassignTime">Set Autoassign Time</button>
         </div>
         <div class="box block">
-            The hour you want outfit suggestions via Telegram (UTC). Leave empty to disable.
+            The hour your household wants outfit suggestions via Telegram (UTC). Leave empty to disable.
             <input class="input" type="number" min="0" max="23" v-model="outfit_hour" />
             <button class="button is-round" @click="setOutfitHour">Set Outfit Hour</button>
             <button class="button is-round" @click="clearOutfitHour">Disable Outfit Notifications</button>
+            <hr />
+            <label class="checkbox">
+                <input type="checkbox" v-model="outfit_opted_in" @change="toggleOutfitReminders" />
+                Receive outfit reminder notifications for me
+            </label>
         </div>
         <div class="box block">
             Expecting? When did it start?
@@ -80,12 +85,14 @@ import UserIcon from "@/components/UserIconComponent.vue";
 export default defineComponent({
     name: 'HomeView',
     data() {
+        const store = useUserStore();
         return {
             invite_link: "",
             error: "",
             magic_link: "",
             autoassign_hour: 8,
             outfit_hour: "",
+            outfit_opted_in: store._user != null ? store._user.outfit_reminders === 1 : true,
             expecting_date: "",
             max_expecting_date: new Date().toISOString().split("T")[0],
         }
@@ -144,6 +151,17 @@ export default defineComponent({
             }
             else {
                 this.error = invite.message;
+            }
+        },
+        toggleOutfitReminders: async function () {
+            this.error = "";
+            const result = await useUserStore().SetOutfitReminders(this.outfit_opted_in);
+            if (result.success == false) {
+                this.error = (result as any).message;
+                this.outfit_opted_in = !this.outfit_opted_in;
+            }
+            else {
+                this.error = this.outfit_opted_in ? "outfit reminders enabled for you" : "outfit reminders disabled for you";
             }
         },
         setOutfitHour: async function () {


### PR DESCRIPTION
Previously outfit reminders were sent to all household members when
the household-level outfit hour was set. Now each member can opt in
or out of receiving outfit reminders via a checkbox on the household
settings page, while the household still controls the reminder hour.

- Add migration v11: outfit_reminders column on users table (default 1)
- Add UserSetOutfitReminders DB method and me.setOutfitReminders tRPC
- Add HouseholdTelegramMessageOutfitMembers that filters by preference
- Update outfit trigger to only message opted-in members
- Add toggle checkbox UI in HouseholdView

https://claude.ai/code/session_01FsVBtsoLVHwEerfuj4C9zC