### PR TITLE
Fix outfit/chore hour not populating in household settings UI

### DIFF
--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -1857,12 +1857,15 @@ export default class Database {
             }
             const current_task = await this.TaskAutoAssignGet(id);
             const current_project = (current_task != null && current_task.project != null) ? (await self.ProjectGet(current_task.project)) : null;
+            const autoAssign = await this._db.selectFrom("houseautoassign").select(["choreAssignHour", "outfitHour"]).where("house_id", "==", id).executeTakeFirst();
             const extended_household: DbHouseholdExtendedRaw = {
                 id: id,
                 name: sql_household.name,
                 members,
                 current_task,
                 current_project,
+                choreAssignHour: autoAssign?.choreAssignHour ?? null,
+                outfitHour: autoAssign?.outfitHour ?? null,
             }
             const result = DbHouseholdExtendedZ.parse(extended_household);
             await this.CacheSet(cache_key, result);

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -250,7 +250,9 @@ export const DbHouseholdExtendedRawZ = z.object({
     name: DbHouseholdRawZ.shape.name,
     current_task: DbTaskZ.nullable(),
     current_project: DbProjectZ.nullable(),
-    members: z.array(DbHouseholdExtendedMemberRawZ)
+    members: z.array(DbHouseholdExtendedMemberRawZ),
+    choreAssignHour: z.number().lt(24).nonnegative().nullable(),
+    outfitHour: z.number().lt(24).nonnegative().nullable(),
 });
 export const DbHouseholdExtendedZ = DbHouseholdExtendedRawZ.brand<"DbHouseholdExtended">()
 export type DbHouseholdExtendedRaw = z.infer<typeof DbHouseholdExtendedRawZ>;

--- a/src/views/HouseholdView.vue
+++ b/src/views/HouseholdView.vue
@@ -97,6 +97,16 @@ export default defineComponent({
     computed: {
         ...mapState(useUserStore, ["userName", "household"])
     },
+    mounted() {
+        if (this.household != null) {
+            if (this.household.choreAssignHour != null) {
+                this.autoassign_hour = this.household.choreAssignHour;
+            }
+            if (this.household.outfitHour != null) {
+                this.outfit_hour = String(this.household.outfitHour);
+            }
+        }
+    },
     methods: {
         copyInviteLink: async function () {
             try {


### PR DESCRIPTION
The outfitHour and choreAssignHour fields were stored in the
houseautoassign table but never included in the extended household
data sent to the frontend. The HouseholdView always showed empty/default
values instead of the actual saved settings.

- Add choreAssignHour and outfitHour to DbHouseholdExtendedRawZ schema
- Query houseautoassign table in HouseholdGetExtended to include values
- Populate the input fields from household data on component mount

https://claude.ai/code/session_0154V1jEiywmN6j7wfZVMaF6