### PR TITLE
Make magic links reusable and improve error page messages

### DIFF
--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -380,25 +380,22 @@ export default class Database {
         return true;
     }
 
-    async UserMagicKeyConsume(magic_key: DbMagicKey): Promise<DbUser | null> {
+    async UserMagicKeyLookup(magic_key: DbMagicKey): Promise<{user: DbUser | null, error: string | null}> {
         const id = this.UserMagicKeyGetId(magic_key);
-        if (id == null) return null;
+        if (id == null) return {user: null, error: "MAGICKEY_INVALID"};
         const result = await this.queryKVJson(id);
-        if (result == null) return null;
-        // Keep track of this promise so we can make sure it gets done later
-        const promise = this.deleteKey(id);
+        if (result == null) return {user: null, error: "MAGICKEY_NOT_FOUND"};
         const user_id = UserIdZ.safeParse(result);
         if (user_id.success == false) {
-            // This is an error, log it
-            console.error("UserMagicKeyConsume", "Unable to parse information in magic key", result);
-            await promise;
-            return null;
+            console.error("UserMagicKeyLookup", "Unable to parse information in magic key", result);
+            return {user: null, error: "MAGICKEY_CORRUPT"};
         }
-        // Query the user
         const user = await this.UserGet(user_id.data);
-        // make sure to wait for this to get deleted
-        await promise;
-        return user;
+        if (user == null) {
+            console.error("UserMagicKeyLookup", "Magic key references user that no longer exists", user_id.data);
+            return {user: null, error: "USER_DB_MISMATCH"};
+        }
+        return {user, error: null};
     }
 
     async HouseholdGenerateUUID() {

--- a/src/views/400View.vue
+++ b/src/views/400View.vue
@@ -1,10 +1,95 @@
 <template>
-<div class="about">
-    <h1>400 You Done Messed Up</h1>
-    <router-link to="/">Take me home</router-link>
+<div class="about container">
+    <h1 class="title is-3 mt-5">Something went wrong</h1>
+    <div class="notification" :class="notificationClass">
+        <p class="is-size-5">{{ errorMessage }}</p>
+        <p v-if="errorDetail" class="mt-2">{{ errorDetail }}</p>
+    </div>
+    <div class="mt-4">
+        <router-link to="/" class="button is-link is-outlined">Take me home</router-link>
+        <a v-if="magicKey" :href="'/auth/magic/' + magicKey" class="button is-primary is-outlined ml-2">Try magic link again</a>
+    </div>
 </div>
 </template>
 
-<!-- <script lang="ts">
-// TODO: read in error code type if needed?
-</script> -->
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+import { useRoute } from 'vue-router';
+
+const ERROR_MESSAGES: Record<string, { message: string; detail?: string; type: string }> = {
+    ALREADY_LOGGEDIN: {
+        message: "You're already logged in.",
+        detail: "Sign out first if you want to use a magic link for a different account.",
+        type: "is-warning",
+    },
+    TELEGRAM_CRAWLER: {
+        message: "Telegram tried to preview this link.",
+        detail: "Open the magic link in your browser directly instead of previewing it in Telegram.",
+        type: "is-info",
+    },
+    MAGICKEY_INVALID: {
+        message: "This magic link is invalid.",
+        detail: "The link appears to be malformed. Try generating a new magic link from a device that's already logged in.",
+        type: "is-danger",
+    },
+    MAGICKEY_NOT_FOUND: {
+        message: "This magic link has expired.",
+        detail: "Magic links are only valid for 1 hour. Generate a new one from a device that's already logged in.",
+        type: "is-warning",
+    },
+    MAGICKEY_CORRUPT: {
+        message: "This magic link's data is corrupted.",
+        detail: "Something went wrong on our end. Try generating a new magic link.",
+        type: "is-danger",
+    },
+    USER_NOT_FOUND: {
+        message: "The user for this magic link was not found.",
+        detail: "The account associated with this magic link may have been deleted. Try signing up again.",
+        type: "is-danger",
+    },
+    USER_DB_MISMATCH: {
+        message: "Your account data is out of sync.",
+        detail: "The magic link is valid, but the linked account could not be found in the database. This can happen after a database migration or reset. Try signing up again or contact your household admin.",
+        type: "is-warning",
+    },
+    UNKNOWN_ERROR: {
+        message: "An unexpected error occurred.",
+        detail: "Something went wrong. Try again or generate a new magic link.",
+        type: "is-danger",
+    },
+};
+
+export default defineComponent({
+    name: '400View',
+    setup() {
+        const route = useRoute();
+
+        const msgCode = computed(() => {
+            return (route.query.msg as string) || '';
+        });
+
+        const magicKey = computed(() => {
+            return (route.query.k as string) || '';
+        });
+
+        const errorInfo = computed(() => {
+            return ERROR_MESSAGES[msgCode.value] || {
+                message: "Something went wrong.",
+                detail: msgCode.value ? `Error code: ${msgCode.value}` : "An unknown error occurred.",
+                type: "is-danger",
+            };
+        });
+
+        const errorMessage = computed(() => errorInfo.value.message);
+        const errorDetail = computed(() => errorInfo.value.detail);
+        const notificationClass = computed(() => errorInfo.value.type);
+
+        return {
+            errorMessage,
+            errorDetail,
+            notificationClass,
+            magicKey,
+        };
+    },
+});
+</script>

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -50,13 +50,20 @@ describe('User tests', () => {
 
     expect(await db.UserMagicKeyExists(key)).toBe(true);
 
-    const magic_user = await db.UserMagicKeyConsume(key);
-    expect(magic_user).not.toBeNull();
-    if (magic_user == null) return;
+    const result = await db.UserMagicKeyLookup(key);
+    expect(result.user).not.toBeNull();
+    expect(result.error).toBeNull();
+    if (result.user == null) return;
 
-    expect(magic_user.id).toBe(user.id);
+    expect(result.user.id).toBe(user.id);
 
-    expect(await db.UserMagicKeyExists(key)).toBe(false);
+    // Magic links should NOT be consumed - they stay valid for their full TTL
+    expect(await db.UserMagicKeyExists(key)).toBe(true);
+
+    // Looking up again should still work
+    const result2 = await db.UserMagicKeyLookup(key);
+    expect(result2.user).not.toBeNull();
+    expect(result2.error).toBeNull();
 
   });
 


### PR DESCRIPTION
Magic links are no longer consumed on first use - they stay valid for
their full 1-hour KV TTL so users can click the same link multiple times.

Replace the generic "400 You Done Messed Up" error page with specific,
actionable error messages for each error code (expired link, already
logged in, Telegram crawler, DB mismatch, etc.). The error page now
uses Bulma notification styling and shows a "Try magic link again"
button when a magic key is available.

Also adds a dedicated USER_DB_MISMATCH error for when a magic link
references a user that no longer exists in the database, with clear
guidance about what happened and what to do.

https://claude.ai/code/session_01RCtG9Dz3YyJgGWo2YZTCHq