### PR TITLE
Fix magic link login failing with 'already logged in' error

### DIFF
--- a/functions/auth/magic/[id].ts
+++ b/functions/auth/magic/[id].ts
@@ -10,15 +10,10 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
     const id = context.params.id;
     const user_agent = context.request.headers.get('user-agent') || '';
     if (id == null || id == undefined) return ResponseJsonMissingData();
-    if (context.data.userid != null) {
-        return ResponseRedirect(context.request, "/error?msg=ALREADY_LOGGEDIN&k=" + id)
-    }
     if (user_agent.startsWith("Telegram")) {
         return ResponseRedirect(context.request, "/error?msg=TELEGRAM_CRAWLER");
     }
     const db = context.data.db as Database;
-    const user = context.data.user
-    if (user != null) return ResponseRedirect(context.request, "/error?msg=ALREADY_LOGGEDIN");
     if (Array.isArray(id)) {
         console.error("AUTH/MAGIC/[id]", "auth/magic ID IS ARRAY", id);
         return ResponseRedirect(context.request, "/error?msg=MAGICKEY_INVALID");


### PR DESCRIPTION
The magic link handler rejected users who had existing valid cookies
(e.g. an unexpired DEVICE_TOKEN), redirecting them to an error page
instead of re-authenticating. Remove the ALREADY_LOGGEDIN guards so
magic links always issue fresh tokens regardless of current session
state.

https://claude.ai/code/session_01G63a4yZjnq8Ft54rJXLKAN