### PR TITLE
Improve error diagnostics across all frontend error handling

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -250,7 +250,7 @@ export default defineComponent({
       if (id == null) return;
       const status = await useUserStore().TaskComplete(id);
       if (status.success == false) {
-        this.error = (status as any).message
+        this.error = status.message
       }
     },
   }

--- a/src/views/HouseholdView.vue
+++ b/src/views/HouseholdView.vue
@@ -125,8 +125,7 @@ export default defineComponent({
             this.error = "";
             const result = await useUserStore().HouseholdSetExpectingDate(this.expecting_date);
             if (result.success == false) {
-                // not sure why typescript is being dumb here and no picking up the fact that message will be valid here?
-                this.error = (result as any).message;
+                this.error = result.message;
             }
             else {
                 if (this.expecting_date == "") {
@@ -157,7 +156,7 @@ export default defineComponent({
             this.error = "";
             const result = await useUserStore().SetOutfitReminders(this.outfit_opted_in);
             if (result.success == false) {
-                this.error = (result as any).message;
+                this.error = result.message;
                 this.outfit_opted_in = !this.outfit_opted_in;
             }
             else {
@@ -173,7 +172,7 @@ export default defineComponent({
             }
             const result = await useUserStore().HouseholdSetOutfitHour(hour);
             if (result.success == false) {
-                this.error = (result as any).message;
+                this.error = result.message;
             }
             else {
                 this.error = hour != null ? "successfully set outfit hour" : "outfit notifications disabled";
@@ -183,7 +182,7 @@ export default defineComponent({
             this.outfit_hour = "";
             const result = await useUserStore().HouseholdSetOutfitHour(null);
             if (result.success == false) {
-                this.error = (result as any).message;
+                this.error = result.message;
             }
             else {
                 this.error = "outfit notifications disabled";
@@ -194,8 +193,7 @@ export default defineComponent({
             this.error = "";
             const result = await useUserStore().HouseholdSetSyncTime(this.autoassign_hour);
             if (result.success == false) {
-                // not sure why typescript is being dumb here and no picking up the fact that message will be valid here?
-                this.error = (result as any).message;
+                this.error = result.message;
             }
             else {
                 this.error = "successfully set time"

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -79,7 +79,7 @@ export default defineComponent({
         this.project_name = "";
       }
       else {
-        this.error = (status as any).message || "unknown error";
+        this.error = status.message;
       }
     }
   }

--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -228,7 +228,7 @@ export default defineComponent({
         return;
       }
       else {
-        this.error = (status as any).message || "unknown error";
+        this.error = status.message;
       }
     },
     complete_task: async function (id: TaskId) {
@@ -237,7 +237,7 @@ export default defineComponent({
         useUserStore().TasksFetch(this.project_id);
       }
       else {
-        this.error = (status as any).message || "unknown error";
+        this.error = status.message;
       }
     },
     delete_task: async function (id: TaskId) {
@@ -246,7 +246,7 @@ export default defineComponent({
         useUserStore().TasksFetch(this.project_id);
       }
       else {
-        this.error = (status as any).message || "unknown error";
+        this.error = status.message;
       }
     },
     add_task: async function () {
@@ -266,7 +266,7 @@ export default defineComponent({
         this.requirement2 = "";
       }
       else {
-        this.error = (status as any).message || "unknown error";
+        this.error = status.message;
       }
     }
   }


### PR DESCRIPTION
Replace uninformative error messages ("unknown error", "TBI",
"Server says no", "Unknown error occurred") with structured
diagnostic information throughout the app.

Central handleError() now extracts details from tRPC errors
(code + HTTP status), Axios errors (response message + status),
Zod validation errors (field-level issues), and generic errors.

Add explicit APIResult return types to store actions that were
missing them, fixing TypeScript narrowing so views no longer
need (status as any).message casts.

https://claude.ai/code/session_013Sh6G9cqF7PBnPo9BkVdva