### PR TITLE
Implement telegram outfit suggestions with dirty/laundry flow

### DIFF
--- a/functions/_outfit/index.ts
+++ b/functions/_outfit/index.ts
@@ -1,0 +1,179 @@
+import { DbClothing, ClothingId } from "../db_types";
+
+// Outfit slots that we compose an outfit from, in display order
+export type OutfitSlot = "coat" | "shirt" | "pants" | "shoes" | "socks";
+
+export const OUTFIT_DISPLAY_ORDER: OutfitSlot[] = ["coat", "shirt", "pants", "shoes"];
+
+/**
+ * Classify a clothing item into an outfit slot based on its category/subcategory.
+ * Returns null if the item doesn't fit any known slot.
+ */
+export function classifyClothing(item: DbClothing): OutfitSlot | null {
+    const cat = item.category.toLowerCase();
+    const subcat = item.subcategory.toLowerCase();
+
+    // Socks (check first - most specific)
+    if (cat.includes("sock") || subcat.includes("sock")) return "socks";
+
+    // Shoes / footwear
+    if (cat.includes("shoe") || cat.includes("footwear") ||
+        subcat.includes("shoe") || subcat.includes("boot") ||
+        subcat.includes("sneaker") || subcat.includes("sandal") ||
+        subcat.includes("loafer") || subcat.includes("slipper")) return "shoes";
+
+    // Outerwear / coats
+    if (cat.includes("outerwear") || cat.includes("coat") || cat.includes("jacket") ||
+        subcat.includes("coat") || subcat.includes("jacket") ||
+        subcat.includes("hoodie") || subcat.includes("parka") ||
+        subcat.includes("blazer") || subcat.includes("vest")) return "coat";
+
+    // Tops / shirts
+    if (cat.includes("top") || cat.includes("shirt") ||
+        subcat.includes("shirt") || subcat.includes("blouse") ||
+        subcat.includes("tee") || subcat.includes("t-shirt") ||
+        subcat.includes("polo") || subcat.includes("sweater") ||
+        subcat.includes("pullover") || subcat.includes("tank") ||
+        subcat.includes("henley") || subcat.includes("button")) return "shirt";
+
+    // Bottoms / pants
+    if (cat.includes("bottom") || cat.includes("pant") || cat.includes("trouser") ||
+        subcat.includes("pant") || subcat.includes("jean") ||
+        subcat.includes("short") || subcat.includes("skirt") ||
+        subcat.includes("chino") || subcat.includes("trouser") ||
+        subcat.includes("jogger") || subcat.includes("cargo")) return "pants";
+
+    return null;
+}
+
+/** Items grouped by outfit slot */
+export interface SlottedClothing {
+    coat: DbClothing[];
+    shirt: DbClothing[];
+    pants: DbClothing[];
+    shoes: DbClothing[];
+    socks: DbClothing[];
+}
+
+/** A generated outfit with one item per slot (optional for coat) */
+export interface GeneratedOutfit {
+    coat: DbClothing | null;
+    shirt: DbClothing | null;
+    pants: DbClothing | null;
+    shoes: DbClothing | null;
+    sockColor: string | null;
+    backupSockColor: string | null;
+}
+
+/**
+ * Group clothing items into outfit slots, filtering to only clean items.
+ */
+export function groupCleanClothingBySlot(items: DbClothing[]): SlottedClothing {
+    const result: SlottedClothing = {
+        coat: [],
+        shirt: [],
+        pants: [],
+        shoes: [],
+        socks: [],
+    };
+
+    for (const item of items) {
+        if (item.is_clean !== 1) continue;
+        const slot = classifyClothing(item);
+        if (slot != null) {
+            result[slot].push(item);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Pick a random item from an array, or null if empty.
+ */
+function pickRandom<T>(items: T[]): T | null {
+    if (items.length === 0) return null;
+    const index = Math.floor(Math.random() * items.length);
+    return items[index];
+}
+
+/**
+ * Get sock color recommendations from available clean socks.
+ * Returns [primary, backup] colors.
+ */
+function pickSockColors(socks: DbClothing[]): [string | null, string | null] {
+    if (socks.length === 0) return [null, null];
+
+    const primary = pickRandom(socks);
+    if (primary == null) return [null, null];
+
+    const primaryColor = primary.color || primary.name;
+
+    // Pick a backup that's a different color if possible
+    const others = socks.filter(s => s.id !== primary.id && (s.color || s.name) !== primaryColor);
+    const backup = pickRandom(others);
+    const backupColor = backup ? (backup.color || backup.name) : null;
+
+    return [primaryColor, backupColor];
+}
+
+/**
+ * Generate an outfit from the available clean clothing.
+ * Returns the outfit and a list of missing slots.
+ */
+export function generateOutfit(items: DbClothing[]): { outfit: GeneratedOutfit; missingSlots: OutfitSlot[] } {
+    const slotted = groupCleanClothingBySlot(items);
+
+    const coat = pickRandom(slotted.coat);
+    const shirt = pickRandom(slotted.shirt);
+    const pants = pickRandom(slotted.pants);
+    const shoes = pickRandom(slotted.shoes);
+    const [sockColor, backupSockColor] = pickSockColors(slotted.socks);
+
+    const outfit: GeneratedOutfit = {
+        coat,
+        shirt,
+        pants,
+        shoes,
+        sockColor,
+        backupSockColor,
+    };
+
+    // Required slots: shirt, pants, shoes. Coat is optional.
+    const missingSlots: OutfitSlot[] = [];
+    if (shirt == null) missingSlots.push("shirt");
+    if (pants == null) missingSlots.push("pants");
+    if (shoes == null) missingSlots.push("shoes");
+
+    return { outfit, missingSlots };
+}
+
+/**
+ * Get all clothing item IDs from a generated outfit (non-null items only).
+ */
+export function getOutfitClothingIds(outfit: GeneratedOutfit): ClothingId[] {
+    const ids: ClothingId[] = [];
+    if (outfit.coat) ids.push(outfit.coat.id);
+    if (outfit.shirt) ids.push(outfit.shirt.id);
+    if (outfit.pants) ids.push(outfit.pants.id);
+    if (outfit.shoes) ids.push(outfit.shoes.id);
+    return ids;
+}
+
+/**
+ * Get image URLs from outfit items, in display order (coat, shirt, pants, shoes).
+ * Only includes items that have images.
+ */
+export function getOutfitImages(outfit: GeneratedOutfit): { url: string; caption: string }[] {
+    const images: { url: string; caption: string }[] = [];
+    for (const slot of OUTFIT_DISPLAY_ORDER) {
+        const item = outfit[slot];
+        if (item && item.image_url) {
+            images.push({
+                url: item.image_url,
+                caption: item.name,
+            });
+        }
+    }
+    return images;
+}

--- a/functions/api/routers/clothes.ts
+++ b/functions/api/routers/clothes.ts
@@ -35,6 +35,7 @@ const Router = router({
     size: z.string().max(50).optional(),
     image_url: z.string().max(1024).optional(),
     tags: z.string().max(1024).optional(),
+    max_wears: z.number().positive().optional(),
   })).query(async (ctx) => {
     if (ctx.ctx.data.user == null) {
       throw new TRPCError({ code: "NOT_FOUND", cause: "User was not found" });

--- a/functions/database/_telegram.ts
+++ b/functions/database/_telegram.ts
@@ -313,6 +313,16 @@ export class TelegramAPI {
         return results.result;
     }
 
+    public async sendMediaGroup(chat_id: string|number, media: {type: "photo", media: string, caption?: string}[]) {
+        const data = {
+            chat_id,
+            media,
+        };
+        const results = await this.requestPost('sendMediaGroup', data);
+        if (results == false) return false;
+        return results.result;
+    }
+
     public async clearMessageReplyMarkup(chat_id:number|string, message_id: number) {
         const data = {
             chat_id,

--- a/functions/database/migration.ts
+++ b/functions/database/migration.ts
@@ -245,6 +245,22 @@ const HoneydewVersion11 = {
     }
 }
 
+const HoneydewVersion12 = {
+    async up(db: Kysely<any>): Promise<void> {
+        {
+            const table_name = "CLOTHES"
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('max_wears', "integer", (col)=>col.defaultTo(1).notNull()) // number of wears before needing a wash
+                .execute()
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('wears_since_wash', "integer", (col)=>col.defaultTo(0).notNull()) // wears since last wash, resets on clean
+                .execute()
+        }
+    }
+}
+
 export const HoneydewMigrations: Migration[] = [
     HoneydewVersion1,
     HoneydewVersion2,
@@ -256,6 +272,7 @@ export const HoneydewMigrations: Migration[] = [
     HoneydewVersion8,
     HoneydewVersion9,
     HoneydewVersion10,
-    HoneydewVersion11
+    HoneydewVersion11,
+    HoneydewVersion12
 ]
 export const LatestHoneydewDBVersion = HoneydewMigrations.length;

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -94,9 +94,20 @@ const TelegramCallbackKVPayloadCompleteChoreZ = TelegramCallbackKVPayloadBaseZ.e
 const TelegramCallbackKVPayloadAnotherChoreZ = TelegramCallbackKVPayloadBaseZ.extend({
     type: z.literal("ANOTHER_CHORE"),
 });
+const TelegramCallbackKVPayloadOutfitDirtyZ = TelegramCallbackKVPayloadBaseZ.extend({
+    type: z.literal("OUTFIT_DIRTY"),
+    clothing_id: ClothingIdZ,
+    house_id: HouseIdZ,
+});
+const TelegramCallbackKVPayloadOutfitLaundryZ = TelegramCallbackKVPayloadBaseZ.extend({
+    type: z.literal("OUTFIT_LAUNDRY"),
+    house_id: HouseIdZ,
+});
 export const TelegramCallbackKVPayloadZ = z.discriminatedUnion("type", [
     TelegramCallbackKVPayloadCompleteChoreZ,
     TelegramCallbackKVPayloadAnotherChoreZ,
+    TelegramCallbackKVPayloadOutfitDirtyZ,
+    TelegramCallbackKVPayloadOutfitLaundryZ,
 ]);
 
 export type TelegramCallbackKVPayload = z.infer<typeof TelegramCallbackKVPayloadZ>;
@@ -271,10 +282,12 @@ export const DbClothingZRaw = z.object({
     size: z.string().max(50),
     image_url: z.string().max(1024),       // URL to clothing image
     tags: z.string().max(1024),            // comma-separated tags (e.g. "casual,summer,work")
-    wear_count: z.number().nonnegative(),  // how many times the item has been worn
+    wear_count: z.number().nonnegative(),  // how many times the item has been worn (lifetime)
     is_clean: z.number().nonnegative(),    // 1 = clean, 0 = dirty (SQLite boolean)
     added_by: UserIdZ,
     created_at: z.number().nonnegative(),  // julian day number when added
+    max_wears: z.number().positive(),      // number of wears before needing a wash (default 1)
+    wears_since_wash: z.number().nonnegative(), // wears since last wash, resets when cleaned
 });
 export const DbClothingZ = DbClothingZRaw.brand<"Clothing">();
 export type DbClothingRaw = z.infer<typeof DbClothingZRaw>;

--- a/functions/triggers/schedule/outfits.ts
+++ b/functions/triggers/schedule/outfits.ts
@@ -1,12 +1,131 @@
 import Database from "../../database/_db";
+import { TelegramInlineKeyboardMarkup } from "../../database/_telegram";
+import { DbUser, HouseId, TelegramCallbackKVPayload } from "../../db_types";
+import { generateOutfit, getOutfitImages, GeneratedOutfit, OUTFIT_DISPLAY_ORDER } from "../../_outfit";
+
+/**
+ * Build the text description for an outfit, including sock recommendations.
+ */
+function buildOutfitText(outfit: GeneratedOutfit): string {
+    const lines: string[] = [];
+    lines.push("Today's outfit suggestion:");
+    lines.push("");
+
+    for (const slot of OUTFIT_DISPLAY_ORDER) {
+        const item = outfit[slot];
+        const label = slot.charAt(0).toUpperCase() + slot.slice(1);
+        if (item) {
+            const details = [item.name, item.color, item.brand].filter(Boolean).join(" - ");
+            lines.push(`${label}: ${details}`);
+        }
+    }
+
+    lines.push("");
+    if (outfit.sockColor) {
+        lines.push(`Socks: ${outfit.sockColor}`);
+        if (outfit.backupSockColor) {
+            lines.push(`Backup socks: ${outfit.backupSockColor}`);
+        }
+    }
+
+    return lines.join("\n");
+}
+
+/**
+ * Send an outfit to a single user via Telegram, with images and dirty buttons.
+ */
+export async function sendOutfitToUser(db: Database, user: DbUser, house_id: HouseId): Promise<boolean> {
+    const chat_id = user._chat_id;
+    if (chat_id == null) return false;
+
+    const allClothes = await db.ClothingGetAll(house_id);
+    const { outfit, missingSlots } = generateOutfit(allClothes);
+
+    // If we can't generate an outfit (missing required slots), ask about laundry
+    if (missingSlots.length > 0) {
+        return await sendLaundryPrompt(db, user, house_id, missingSlots);
+    }
+
+    const telegram = db.GetTelegram();
+    const images = getOutfitImages(outfit);
+
+    // Send photos as a media group if we have 2+ images
+    if (images.length >= 2) {
+        const media = images.map((img) => ({
+            type: "photo" as const,
+            media: img.url,
+            caption: img.caption,
+        }));
+        await telegram.sendMediaGroup(chat_id, media);
+    } else if (images.length === 1) {
+        await telegram.sendPhoto(chat_id, images[0].url, images[0].caption);
+    }
+
+    // Build dirty buttons for each clothing item in the outfit
+    const buttons: { text: string; callback_data: string }[] = [];
+    for (const slot of OUTFIT_DISPLAY_ORDER) {
+        const item = outfit[slot];
+        if (item == null) continue;
+        const payload: TelegramCallbackKVPayload = {
+            type: "OUTFIT_DIRTY",
+            user_id: user.id,
+            clothing_id: item.id,
+            house_id,
+        };
+        const key = await db.TelegramCallbackCreate(payload);
+        if (key != null) {
+            const label = slot.charAt(0).toUpperCase() + slot.slice(1);
+            buttons.push({ text: `${label} is dirty`, callback_data: key });
+        }
+    }
+
+    const text = buildOutfitText(outfit);
+
+    const keyboard: TelegramInlineKeyboardMarkup = {
+        // One button per row so they're easy to tap
+        inline_keyboard: buttons.map(b => [b]),
+    };
+
+    await telegram.sendTextMessage(chat_id, text, undefined, keyboard);
+    return true;
+}
+
+/**
+ * Send a laundry prompt when no outfit can be generated.
+ */
+async function sendLaundryPrompt(db: Database, user: DbUser, house_id: HouseId, missingSlots: string[]): Promise<boolean> {
+    const chat_id = user._chat_id;
+    if (chat_id == null) return false;
+
+    const payload: TelegramCallbackKVPayload = {
+        type: "OUTFIT_LAUNDRY",
+        user_id: user.id,
+        house_id,
+    };
+    const key = await db.TelegramCallbackCreate(payload);
+
+    const missingText = missingSlots.join(", ");
+    const text = `I can't put together an outfit today - no clean items for: ${missingText}. Has laundry been done?`;
+
+    if (key != null) {
+        const keyboard: TelegramInlineKeyboardMarkup = {
+            inline_keyboard: [[{ text: "Laundry is done!", callback_data: key }]],
+        };
+        await db.GetTelegram().sendTextMessage(chat_id, text, undefined, keyboard);
+    } else {
+        await db.GetTelegram().sendTextMessage(chat_id, text);
+    }
+    return true;
+}
 
 export const TriggerOutfits = async function (db: Database, hour: number) {
     // Get all households that have opted into outfit notifications for this hour
     const households = await db.HouseOutfitGetHousesReadyForGivenHour(hour);
 
-    const message = "Clothing choices under construction";
     const promises = households.map(async (house_id) => {
-        await db.HouseholdTelegramMessageOutfitMembers(house_id, message);
+        const users = await db.HouseholdGetOutfitOptedInUsers(house_id);
+        const userPromises = users.map(user => sendOutfitToUser(db, user, house_id));
+        await Promise.allSettled(userPromises);
         await db.HouseOutfitMarkComplete(house_id);
         return house_id;
     });


### PR DESCRIPTION
Adds a complete outfit suggestion system that generates daily outfits from
clean clothing, sends them via Telegram with photos and "mark dirty" buttons,
and handles the full laundry cycle when no clean items are available.

Key changes:
- Add max_wears and wears_since_wash fields to clothing (migration V12)
- Clothing stays clean until worn max_wears times, then becomes dirty
- New outfit module classifies clothing into slots (coat/shirt/pants/shoes/socks)
- Outfit trigger generates per-user outfits with image media groups
- Sock color and backup sock color recommendations
- OUTFIT_DIRTY callback: marks item dirty, regenerates outfit
- OUTFIT_LAUNDRY callback: marks all household clothes clean, regenerates
- Fix UserRegisterTelegram not invalidating user cache
- 17 new tests covering classification, generation, triggers, and callbacks

https://claude.ai/code/session_016Uf8d8WsrmGKoiTegSrjpU