### PR TITLE
Fix Telegram magic links failing due to URL-unsafe chars and JWT exp bug

### DIFF
--- a/functions/auth/magic/[id].ts
+++ b/functions/auth/magic/[id].ts
@@ -39,7 +39,7 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
     const generic_token = await jwt.sign({
         id: magic_user.id,
         name: magic_user.name,
-        exp: Math.floor(Date.now() / 1000) + 12, //(12 * (60 * 60)) // Expires: Now + 12h
+        exp: Math.floor(Date.now() / 1000) + (12 * (60 * 60)), // Expires: Now + 12h
     }, secret);
 
     const redirect = '<head><meta http-equiv="Refresh" content="0; URL=/household" /></head>';

--- a/functions/auth/signup.ts
+++ b/functions/auth/signup.ts
@@ -14,7 +14,7 @@ export async function GiveNewTemporaryCookie(env: HoneydewPageEnv, response:Resp
      const generic_token = await jwt.sign({
         id: user.id,
         name: user.name,
-        exp: Math.floor(Date.now() / 1000) + 12, //(12 * (60 * 60)) // Expires: Now + 12h
+        exp: Math.floor(Date.now() / 1000) + (12 * (60 * 60)), // Expires: Now + 12h
     }, secret);
 
     setCookie(response, TEMP_TOKEN, generic_token, false);

--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -26,7 +26,7 @@ const timer = (ms: number) => new Promise(res => setTimeout(res, ms));
 
 function makeid(length: number) {
     let result = '';
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+~_$@';
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
     const charactersLength = characters.length;
     let counter = 0;
     while (counter < length) {

--- a/functions/telegram/_handler.ts
+++ b/functions/telegram/_handler.ts
@@ -51,7 +51,15 @@ export async function HandleTelegramUpdateMessage(db: Database, message: Telegra
             return ResponseJsonOk();
         }
         const link = `https://honeydew.matthewc.dev/auth/magic/${key}`;
-        await db.GetTelegram().sendTextMessage(chat.id, `Here's your magic sign-in link (expires in 1 hour):\n${link}`, x.message.message_id);
+        const keyboard: TelegramInlineKeyboardMarkup = {
+            inline_keyboard: [[
+                {
+                    text: "Sign in with magic link",
+                    url: link,
+                },
+            ]]
+        };
+        await db.GetTelegram().sendTextMessage(chat.id, "Here's your magic sign-in link (expires in 1 hour):", x.message.message_id, keyboard);
         return ResponseJsonOk();
     }
 


### PR DESCRIPTION
Two issues were causing magic links from Telegram to fail:

1. The makeid() function used characters (+, ~, $, @) that break
   Telegram's URL auto-detection when the link is sent as plain text.
   Changed to URL-safe charset (A-Za-z0-9, -, _). Also send the magic
   link as a Telegram inline keyboard button for reliable URL handling.

2. JWT TEMP_TOKEN expiration was set to 12 seconds instead of 12 hours -
   the multiplication (12 * 60 * 60) was commented out in both
   magic/[id].ts and signup.ts GiveNewTemporaryCookie.

https://claude.ai/code/session_01L45uYZ1YArnqPwggtchCWi