### PR TITLE
Fix Telegram login errors showing generic "unknown error" message

### DIFF
--- a/functions/auth/check.ts
+++ b/functions/auth/check.ts
@@ -27,9 +27,19 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
         id: user.id,
         color: user.color,
         icon: user.icon,
+        outfit_reminders: user.outfit_reminders,
     }
-    
-    const result_json = JSON.stringify(AuthCheckZ.parse(final_results));
-    // Should we provide information 
+
+    let result_json: string;
+    try {
+        result_json = JSON.stringify(AuthCheckZ.parse(final_results));
+    } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.error("AUTH_CHECK_PARSE_FAILED", errorMsg, final_results);
+        return new Response(
+            `window.logged_in = false; window.login_error = "AUTH_CHECK_PARSE_FAILED"; // ${errorMsg.replace(/[^\w\s:,]/g, '')}`,
+            { headers: { "Content-Type": "application/javascript" } },
+        );
+    }
     return new Response("window.logged_in = true; window.user_data = " + result_json, { headers: { "Content-Type": "application/javascript" } },)
 }

--- a/functions/auth/magic/[id].ts
+++ b/functions/auth/magic/[id].ts
@@ -31,16 +31,23 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
 
     const secret = context.env.JWT_SECRET;
 
-    // Creating a more secure token?
-    const refresh_token = await jwt.sign({
-        id: magic_user.id,
-        // tokens do not expire just because why not?
-    }, secret);
-    const generic_token = await jwt.sign({
-        id: magic_user.id,
-        name: magic_user.name,
-        exp: Math.floor(Date.now() / 1000) + (12 * (60 * 60)), // Expires: Now + 12h
-    }, secret);
+    let refresh_token: string;
+    let generic_token: string;
+    try {
+        refresh_token = await jwt.sign({
+            id: magic_user.id,
+            // tokens do not expire just because why not?
+        }, secret);
+        generic_token = await jwt.sign({
+            id: magic_user.id,
+            name: magic_user.name,
+            exp: Math.floor(Date.now() / 1000) + (12 * (60 * 60)), // Expires: Now + 12h
+        }, secret);
+    } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        console.error("AUTH/MAGIC/[id]", "JWT signing failed", errorMsg, { userId: magic_user.id });
+        return ResponseRedirect(context.request, "/error?msg=LOGIN_JWT_FAILED");
+    }
 
     const redirect = '<head><meta http-equiv="Refresh" content="0; URL=/household" /></head>';
 

--- a/functions/auth/telegram/[id].ts
+++ b/functions/auth/telegram/[id].ts
@@ -12,7 +12,7 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
         return ResponseJsonBadRequest();
     }
     if (context.data.userid == null) {
-        return ResponseRedirect(context.request, "/error?t=TelegramNotLoggedIn")
+        return ResponseRedirect(context.request, "/error?msg=TELEGRAM_NOT_LOGGED_IN")
     }
     const db = context.data.db as Database;
     const user = context.data.user

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -122,7 +122,11 @@ router.beforeEach((to, from) => {
     return true;
   }
   if (to.meta.noAuthRequired == undefined) return true;
-  if (to.meta.noAuthRequired == false) return { name: '400' };
+  if (to.meta.noAuthRequired == false) {
+    const loginError = (window as any).login_error;
+    const msg = loginError || 'AUTH_REQUIRED';
+    return { name: '400', query: { msg } };
+  }
 })
 
 export default router

--- a/src/views/400View.vue
+++ b/src/views/400View.vue
@@ -9,6 +9,11 @@
         <router-link to="/" class="button is-link is-outlined">Take me home</router-link>
         <a v-if="magicKey" :href="'/auth/magic/' + magicKey" class="button is-primary is-outlined ml-2">Try magic link again</a>
     </div>
+    <details v-if="msgCode" class="mt-5">
+        <summary class="has-text-grey is-size-7">Diagnostic info</summary>
+        <pre class="has-text-grey-light is-size-7 mt-2">Error code: {{ msgCode }}
+User agent: {{ userAgent }}</pre>
+    </details>
 </div>
 </template>
 
@@ -52,6 +57,26 @@ const ERROR_MESSAGES: Record<string, { message: string; detail?: string; type: s
         detail: "The magic link is valid, but the linked account could not be found in the database. This can happen after a database migration or reset. Try signing up again or contact your household admin.",
         type: "is-warning",
     },
+    TELEGRAM_NOT_LOGGED_IN: {
+        message: "You need to be logged in to link Telegram.",
+        detail: "Open this link in a browser where you're already signed in to Honeydew, or use a magic link to sign in first.",
+        type: "is-warning",
+    },
+    AUTH_REQUIRED: {
+        message: "You need to sign in first.",
+        detail: "This page requires authentication. Sign in or use a magic link to access it.",
+        type: "is-warning",
+    },
+    AUTH_CHECK_PARSE_FAILED: {
+        message: "Your session loaded but the account data couldn't be read.",
+        detail: "This is a server-side issue. Try clearing your cookies and signing in again, or generate a new magic link.",
+        type: "is-danger",
+    },
+    LOGIN_JWT_FAILED: {
+        message: "Sign-in failed during token creation.",
+        detail: "The server was unable to create your session token. This is a server-side issue. Try again or generate a new magic link.",
+        type: "is-danger",
+    },
     UNKNOWN_ERROR: {
         message: "An unexpected error occurred.",
         detail: "Something went wrong. Try again or generate a new magic link.",
@@ -83,12 +108,15 @@ export default defineComponent({
         const errorMessage = computed(() => errorInfo.value.message);
         const errorDetail = computed(() => errorInfo.value.detail);
         const notificationClass = computed(() => errorInfo.value.type);
+        const userAgent = computed(() => navigator.userAgent);
 
         return {
             errorMessage,
             errorDetail,
             notificationClass,
             magicKey,
+            msgCode,
+            userAgent,
         };
     },
 });


### PR DESCRIPTION
Several issues were causing unhelpful error messages when logging in
via magic links from Telegram:

- /auth/check.ts was missing outfit_reminders field, causing AuthCheckZ
  parse to fail and the auth check script to return a 500 instead of
  setting window.logged_in. Added the field and wrapped parse in
  try-catch so failures set window.login_error for diagnostics.
- /auth/telegram/[id].ts used ?t= query param but error page reads ?msg=
- Router guard redirected to /error without any context, now passes
  msg=AUTH_REQUIRED (or the specific login_error from check.ts)
- Magic link handler had no try-catch around JWT signing
- Added new error codes to 400View: TELEGRAM_NOT_LOGGED_IN,
  AUTH_REQUIRED, AUTH_CHECK_PARSE_FAILED, LOGIN_JWT_FAILED
- Added diagnostic info section (error code + user agent) to error page

https://claude.ai/code/session_011atAqKL9HZ6XPuwCGenU5x