### PR TITLE
Fix auth check missing outfit_reminders causing E2E test failures

### DIFF
--- a/functions/auth/check.ts
+++ b/functions/auth/check.ts
@@ -25,9 +25,10 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
         name: user.name,
         household,
         id: user.id,
+        task: null,
         color: user.color,
         icon: user.icon,
-        outfit_reminders: user.outfit_reminders,
+        outfit_reminders: user.outfit_reminders ?? 0,
     }
 
     let result_json: string;


### PR DESCRIPTION
The AuthCheckZ schema requires `outfit_reminders` and `task` fields,
but check.ts was not including them. This caused AuthCheckZ.parse() to
throw a Zod validation error, making /auth/check return a 500 instead
of setting window.logged_in. Without auth, the Vue router redirected
all authenticated pages to the error page, so the E2E test could never
find the chores input.

https://claude.ai/code/session_01XA8LstfsmUwEWTZ8rmS29D