### PR TITLE
Add default values to schema fields for better type safety

### DIFF
--- a/functions/api/routers/me.ts
+++ b/functions/api/routers/me.ts
@@ -65,6 +65,7 @@ const Router = router({
       id: user.id,
       color: user.color,
       household,
+      task: null,
       outfit_reminders: user.outfit_reminders,
     };
     return AuthCheckZ.parse(result);

--- a/functions/auth/auth_types.ts
+++ b/functions/auth/auth_types.ts
@@ -27,7 +27,7 @@ export const AuthCheckZ = z.object({
     task: z.any(),
     color: z.string().min(7),
     icon: z.string(),
-    outfit_reminders: z.number().nonnegative(),
+    outfit_reminders: z.number().nonnegative().default(0),
 }).strict()
 export type AuthCheck = z.infer<typeof AuthCheckZ>;
 

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -252,8 +252,8 @@ export const DbHouseholdExtendedRawZ = z.object({
     current_task: DbTaskZ.nullable(),
     current_project: DbProjectZ.nullable(),
     members: z.array(DbHouseholdExtendedMemberRawZ),
-    choreAssignHour: z.number().lt(24).nonnegative().nullable(),
-    outfitHour: z.number().lt(24).nonnegative().nullable(),
+    choreAssignHour: z.number().lt(24).nonnegative().nullable().default(null),
+    outfitHour: z.number().lt(24).nonnegative().nullable().default(null),
 });
 export const DbHouseholdExtendedZ = DbHouseholdExtendedRawZ.brand<"DbHouseholdExtended">()
 export type DbHouseholdExtendedRaw = z.infer<typeof DbHouseholdExtendedRawZ>;


### PR DESCRIPTION
## Summary
This PR adds explicit default values to Zod schema fields to improve type safety and ensure consistent data handling across the application.

## Key Changes
- **db_types.ts**: Added `.default(null)` to `choreAssignHour` and `outfitHour` fields in `DbHouseholdExtendedRawZ` schema to explicitly handle null cases
- **auth_types.ts**: Added `.default(0)` to `outfit_reminders` field in `AuthCheckZ` schema to provide a sensible default value
- **me.ts**: Added explicit `task: null` assignment in the result object to match the schema requirements

## Implementation Details
These changes ensure that:
1. Optional numeric fields have explicit default values defined in their schemas
2. The API response in `me.ts` now explicitly includes the `task` field (set to null) to satisfy the `AuthCheckZ` schema validation
3. Type inference from these schemas will now properly include the default values, reducing the need for null checks in consuming code

https://claude.ai/code/session_01HoySqPeVVZcE9afdAxGt9h