### PR TITLE
Fix chore reminders firing at wrong times due to bypassed dedup check

### DIFF
--- a/functions/triggers/schedule/chores.ts
+++ b/functions/triggers/schedule/chores.ts
@@ -4,30 +4,68 @@ import { TelegramAPI } from "../../database/_telegram";
 import { getJulianDate } from "../../_utils";
 import { TriggerOutfits } from "./outfits";
 
+/**
+ * Chore scheduling trigger — called once per hour with the current UTC hour.
+ *
+ * This function handles three things in order:
+ *
+ * 1. **Chore assignment**: For every household whose `choreAssignHour` matches
+ *    the current hour (and hasn't been processed recently), pick the next chore
+ *    for each member and send them a Telegram notification. Users are processed
+ *    sequentially to avoid assigning the same chore to two people.
+ *
+ * 2. **Household task assignment**: For the same set of households, pick the
+ *    next project task and notify all members. Then mark the household as
+ *    processed by advancing `choreLastAssignTime` (prevents re-processing
+ *    for ~24 hours — see `HouseAutoAssignMarkComplete`).
+ *
+ * 3. **Chore reminders (12h later)**: For households whose `choreAssignHour`
+ *    is 12 hours behind the current hour (i.e., chores were assigned earlier
+ *    today), send a reminder to any user who still hasn't completed their
+ *    assigned chore. Uses `HouseAutoAssignGetUsersRecentlyAssigned` which
+ *    checks `choreLastAssignTime > (now - 0.75 days)` to ensure reminders
+ *    only fire when chores were actually assigned recently.
+ *
+ * Deduplication:
+ * - Assignment: guarded by `choreLastAssignTime < (now - 0.5)` — won't
+ *   re-assign until ~12h after last processing.
+ * - Reminders: guarded by `choreLastAssignTime > (now - 0.75)` — only
+ *   fires when chores were assigned within the last ~18h. Also skips
+ *   users who already completed their chore (`lastDone >= lastTimeAssigned`)
+ *   or have no cached chore.
+ */
 export const TriggerChores = async function (db: Database, hour: number) {
-    // then query the database for all the users that need to get processed
+    // Step 1: Assign chores to individual users in matching households.
+    // "Ready" means choreAssignHour == hour AND choreLastAssignTime < (now - 0.5).
     const users = await db.HouseAutoAssignGetUsersReadyForGivenHour(hour);
     for (let i = 0; i < users.length; i++) {
-        // we do this individually so that we don't assign the same chore to two people
-        // the downside is that this is slow
+        // Sequential so two users in the same household don't get the same chore
         const x = users[i];
         await db.ChoreGetNextChore(x.house_id, x.user_id, x.chat_id);
     }
-    // then handle all the households
-    // we can do these all the same time
+
+    // Step 2: Assign a project task to each household, then mark the household
+    // as processed. HouseAutoAssignMarkComplete sets choreLastAssignTime to
+    // (now + 0.02), which prevents Steps 1 and 2 from running again for ~24h.
     const households = await db.HouseAutoAssignGetHousesReadyForGivenHour(hour);
     const promises = households.map((x) => {
         return db.TaskAutoAssignNextTask(x).then((_) => db.HouseAutoAssignMarkComplete(x));
     });
 
-    // Now look at all the users that need a reminder
-    // Find households where chores were assigned 12 hours ago (recently assigned, not ready-for-assignment)
+    // Step 3: Send reminders for chores assigned 12 hours ago.
+    // If this trigger is running at hour H, we look for households whose
+    // choreAssignHour is (H + 12) % 24 — those had their chores assigned
+    // 12 hours ago. We use HouseAutoAssignGetUsersRecentlyAssigned (checks
+    // choreLastAssignTime > now - 0.75) to only match households that were
+    // actually processed today, not stale entries.
     const reminder_hour = (hour + 12) % 24;
     const reminder_users = await db.HouseAutoAssignGetUsersRecentlyAssigned(reminder_hour);
     const reminder_promises = reminder_users.map(async (x) => {
+        // Skip if the user has no current chore cached (already expired or never assigned)
         const chore = await db.ChoreGetCurrentChore(x.user_id);
         if (chore == null) return false;
         if (x.chat_id == null) return false;
+        // Skip if the chore was already completed since it was assigned
         if (chore.lastTimeAssigned != null && chore.lastDone >= chore.lastTimeAssigned) return false;
 
         // Build informative reminder message

--- a/functions/triggers/schedule/chores.ts
+++ b/functions/triggers/schedule/chores.ts
@@ -21,9 +21,9 @@ export const TriggerChores = async function (db: Database, hour: number) {
     });
 
     // Now look at all the users that need a reminder
+    // Find households where chores were assigned 12 hours ago (recently assigned, not ready-for-assignment)
     const reminder_hour = (hour + 12) % 24;
-    const future_date = getJulianDate() + 5;
-    const reminder_users = await db.HouseAutoAssignGetUsersReadyForGivenHour(reminder_hour, future_date); // passing in a zero for timestamp
+    const reminder_users = await db.HouseAutoAssignGetUsersRecentlyAssigned(reminder_hour);
     const reminder_promises = reminder_users.map(async (x) => {
         const chore = await db.ChoreGetCurrentChore(x.user_id);
         if (chore == null) return false;


### PR DESCRIPTION
The reminder query reused HouseAutoAssignGetUsersReadyForGivenHour with
a future timestamp (now + 5 days), which effectively disabled the
choreLastAssignTime guard. This caused reminders to fire every time the
trigger ran at the matching hour, regardless of whether chores were
actually assigned that day — leading to duplicate/spurious reminders.

Added HouseAutoAssignGetUsersRecentlyAssigned that checks
choreLastAssignTime > (now - 0.75) to only find households where chores
were assigned within the last ~18 hours, ensuring reminders only fire
once after actual chore assignment.

https://claude.ai/code/session_01B4PFvHpmsh9Qbh4ERLVQ5E