### PR TITLE
Handle invalid window.user_data gracefully with API re-fetch

### DIFF
--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -162,6 +162,8 @@ export default class Database {
             if (cached_result != null) {
                 const cached_user = DbUserZ.safeParse(cached_result);
                 if (cached_user.success) return cached_user.data;
+                console.warn("UserGet: stale KV cache for", id, "- invalidating");
+                await this.deleteKey(id);
             }
             const raw = await this._db.selectFrom("users").selectAll().where("id", "==", id).executeTakeFirstOrThrow();
             const results = DbUserZ.safeParse(raw);
@@ -433,6 +435,8 @@ export default class Database {
         if (raw_cache != null) {
             const cached_household = DbHouseholdZ.safeParse(raw_cache);
             if (cached_household.success) return cached_household.data;
+            console.warn("HouseholdGet: stale KV cache for", id, "- invalidating");
+            await this.deleteKey(id);
         }
         const sql_data = await this._db.selectFrom("households").selectAll().where("id", "==", id).executeTakeFirst();
         // TODO use a join to get what I want from the DB?
@@ -1870,6 +1874,8 @@ export default class Database {
             if (raw_cache != null) {
                 const raw_results = DbHouseholdExtendedZ.safeParse(raw_cache);
                 if (raw_results.success) return raw_results.data;
+                console.warn("HouseholdGetExtended: stale KV cache for", cache_key, "- invalidating");
+                await this.deleteKey(cache_key);
             }
             const sql_household = await this._db.selectFrom("households").select("name").where("id", "==", id).executeTakeFirstOrThrow();
             // next we need to query the database

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -122,7 +122,7 @@ export const DbUserZRaw = z.object({
     _recoverykey: z.string().max(255),
     _chat_id: z.number().nullable(),
     last_active_date: z.number().nullable(), // Julian day number of last chore completion
-    current_streak: z.number().nonnegative(), // Current consecutive days streak
+    current_streak: z.number().nonnegative().default(0), // Current consecutive days streak
     outfit_reminders: z.number().nonnegative(), // 1 = opted in, 0 = opted out of outfit reminders
 })
 export const DbUserZ = DbUserZRaw.brand<"User">()

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,11 +9,15 @@
 import { defineComponent } from 'vue';
 import FooterComponent from '@/components/FooterComponent.vue'; // @ is an alias to /src
 import HeaderComponent from './components/HeaderComponent.vue';
+import { useUserStore } from '@/store';
 export default defineComponent({
   name: 'App',
   components: {
     HeaderComponent,
     FooterComponent,
+  },
+  mounted() {
+    useUserStore().initialize();
   },
 });
 </script>


### PR DESCRIPTION
When the initial user_data from the auth/check script fails Zod
validation (e.g., stale KV cache missing current_streak), the app
previously logged the error but left _user as null while _loggedIn
was true, causing a broken dashboard with no data.

Changes:
- Add .default(0) to current_streak schema so stale cached data
  without the field still parses correctly
- Add _needsUserFetch flag and initialize() action that auto-fetches
  fresh user data from the me.get tRPC endpoint when initial parse fails
- Extract _hydrateUser() to centralize state population from AuthCheck
- Call initialize() from App.vue mounted hook to trigger recovery
- If API re-fetch also fails, set _loggedIn=false so the user sees
  the landing page instead of a broken authenticated view

https://claude.ai/code/session_01LGgYvCzzDTdziFnsQ9EUGM