### PR TITLE
Add "I'm Out of Town" button to chore reminders to freeze streaks

### DIFF
--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -324,6 +324,38 @@ export default class Database {
         }
     }
 
+    /**
+     * Freezes the user's streak by updating last_active_date to today without
+     * incrementing the streak counter. This prevents the streak from resetting
+     * when the user is out of town.
+     * @returns Object with current streak, or null on failure
+     */
+    async UserFreezeStreak(user_id: UserId): Promise<{ streak: number } | null> {
+        try {
+            const user = await this.UserGet(user_id);
+            if (user == null) return null;
+
+            const today = Math.floor(getJulianDate());
+
+            // If already active today, nothing to do
+            if (user.last_active_date === today) {
+                return { streak: user.current_streak };
+            }
+
+            // Set last_active_date to today but keep the same streak value
+            await this._db.updateTable("users")
+                .where("id", "==", user_id)
+                .set({ last_active_date: today })
+                .execute();
+
+            await this.CacheInvalidate(user_id);
+            return { streak: user.current_streak };
+        } catch (err) {
+            console.error("UserFreezeStreak", err);
+            return null;
+        }
+    }
+
     async UserSetOutfitReminders(raw_user_id: UserId, enabled: boolean): Promise<boolean> {
         try {
             const user_id = UserIdZ.parse(raw_user_id);

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -94,9 +94,14 @@ const TelegramCallbackKVPayloadCompleteChoreZ = TelegramCallbackKVPayloadBaseZ.e
 const TelegramCallbackKVPayloadAnotherChoreZ = TelegramCallbackKVPayloadBaseZ.extend({
     type: z.literal("ANOTHER_CHORE"),
 });
+const TelegramCallbackKVPayloadOutOfTownZ = TelegramCallbackKVPayloadBaseZ.extend({
+    type: z.literal("OUT_OF_TOWN"),
+    chore_id: ChoreIdz,
+});
 export const TelegramCallbackKVPayloadZ = z.discriminatedUnion("type", [
     TelegramCallbackKVPayloadCompleteChoreZ,
     TelegramCallbackKVPayloadAnotherChoreZ,
+    TelegramCallbackKVPayloadOutOfTownZ,
 ]);
 
 export type TelegramCallbackKVPayload = z.infer<typeof TelegramCallbackKVPayloadZ>;

--- a/functions/telegram/_handler.ts
+++ b/functions/telegram/_handler.ts
@@ -93,6 +93,27 @@ async function HandleTelegramCompleteChore(db: Database, message:TelegramUpdateC
     }
 }
 
+async function HandleTelegramOutOfTown(db: Database, message: TelegramUpdateCallbackQuery, payload: TelegramCallbackKVPayload): Promise<TelegramAnswerCallbackQuery|null> {
+    if (payload.type != "OUT_OF_TOWN") return null;
+    const result = await db.UserFreezeStreak(payload.user_id);
+    if (result == null) {
+        return {
+            callback_query_id: message.callback_query.id,
+            text: "Something went wrong, try again from the website",
+        }
+    }
+    // Skip the current chore so it can be reassigned
+    await db.ChoreSkipCurrentChore(payload.user_id);
+    let responseText = "Streak frozen! Enjoy your time away.";
+    if (result.streak > 2) {
+        responseText = `Streak frozen at ${result.streak} days! Enjoy your time away.`;
+    }
+    return {
+        callback_query_id: message.callback_query.id,
+        text: responseText
+    }
+}
+
 export async function HandleTelegramUpdateCallbackQuery(db: Database, message: TelegramUpdateCallbackQuery) {
     try {
         const uuid = message.callback_query.data;
@@ -116,6 +137,9 @@ export async function HandleTelegramUpdateCallbackQuery(db: Database, message: T
         let answer_callback: TelegramAnswerCallbackQuery|null = null;
         if (payload.type == "COMPLETE_CHORE") {
             answer_callback = await HandleTelegramCompleteChore(db, message, payload);
+        }
+        if (payload.type == "OUT_OF_TOWN") {
+            answer_callback = await HandleTelegramOutOfTown(db, message, payload);
         }
         if (answer_callback != null) {
             // console.error("HandleTelegramUpdateCallbackQuery", answer_callback);

--- a/functions/triggers/schedule/chores.ts
+++ b/functions/triggers/schedule/chores.ts
@@ -1,8 +1,9 @@
 import { HoneydewPagesFunction } from "../../types";
 import Database from "../../database/_db";
-import { TelegramAPI } from "../../database/_telegram";
+import { TelegramAPI, TelegramInlineKeyboardMarkup } from "../../database/_telegram";
 import { getJulianDate } from "../../_utils";
 import { TriggerOutfits } from "./outfits";
+import { TelegramCallbackKVPayload } from "../../db_types";
 
 /**
  * Chore scheduling trigger — called once per hour with the current UTC hour.
@@ -88,7 +89,31 @@ export const TriggerChores = async function (db: Database, hour: number) {
         const escapedLastDoneByText = lastDoneByText.replace(/([_*\[\]()~`>#+\-=|{}.!])/g, '\\$1');
 
         const message = `Just a friendly reminder to complete your chore: *${escapedName}*\\! Last done ${escapedDaysAgoText}${escapedLastDoneByText}\\.`
-        await db.GetTelegram().sendTextMessage(x.chat_id, message, undefined, undefined, "MarkdownV2");
+
+        // If the user has an active streak, add an "I'm out of town" button
+        // that freezes the streak without resetting it
+        const user = await db.UserGet(x.user_id);
+        let keyboard: TelegramInlineKeyboardMarkup | undefined;
+        if (user && user.current_streak > 0) {
+            const payload: TelegramCallbackKVPayload = {
+                user_id: x.user_id,
+                type: "OUT_OF_TOWN",
+                chore_id: chore.id,
+            };
+            const payload_key = await db.TelegramCallbackCreate(payload);
+            if (payload_key != null) {
+                keyboard = {
+                    inline_keyboard: [[
+                        {
+                            text: "I'm Out of Town",
+                            callback_data: payload_key
+                        },
+                    ]]
+                };
+            }
+        }
+
+        await db.GetTelegram().sendTextMessage(x.chat_id, message, undefined, keyboard, "MarkdownV2");
         return true;
     })
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1092,6 +1092,103 @@ describe('Streak tests', () => {
     expect(result.streak).toBe(3);
     expect(result.isFirstToday).toBe(true);
   });
+
+  it('UserFreezeStreak preserves streak without incrementing', async () => {
+    const house_id = (await db.HouseholdCreate("Freeze streak house"))?.id;
+    expect(house_id).not.toBeNull();
+    if (house_id == null) return;
+
+    const user_id = (await db.UserCreate("Hank", house_id))?.id;
+    expect(user_id).not.toBeNull();
+    if (user_id == null) return;
+
+    const today = Math.floor(getJulianDate());
+    const d1 = env.HONEYDEWSQL as D1Database;
+    const kv = env.HONEYDEW as KVNamespace;
+
+    // Simulate: user had a 5-day streak, last active yesterday
+    await d1.prepare("UPDATE users SET last_active_date = ?, current_streak = ? WHERE id = ?")
+      .bind(today - 1, 5, user_id)
+      .run();
+    await kv.delete(user_id);
+
+    // Freeze the streak - should keep streak at 5 and update last_active_date
+    const result = await db.UserFreezeStreak(user_id);
+    expect(result).not.toBeNull();
+    expect(result!.streak).toBe(5);
+
+    // Verify it persisted: last_active_date updated but streak unchanged
+    const row = await d1.prepare("SELECT current_streak, last_active_date FROM users WHERE id = ?")
+      .bind(user_id)
+      .first();
+    expect(row).not.toBeNull();
+    expect(row!.current_streak).toBe(5);
+    expect(row!.last_active_date).toBe(today);
+  });
+
+  it('UserFreezeStreak is idempotent on same day', async () => {
+    const house_id = (await db.HouseholdCreate("Freeze idempotent house"))?.id;
+    expect(house_id).not.toBeNull();
+    if (house_id == null) return;
+
+    const user_id = (await db.UserCreate("Ivy", house_id))?.id;
+    expect(user_id).not.toBeNull();
+    if (user_id == null) return;
+
+    const today = Math.floor(getJulianDate());
+    const d1 = env.HONEYDEWSQL as D1Database;
+    const kv = env.HONEYDEW as KVNamespace;
+
+    // Simulate: user already active today with a 3-day streak
+    await d1.prepare("UPDATE users SET last_active_date = ?, current_streak = ? WHERE id = ?")
+      .bind(today, 3, user_id)
+      .run();
+    await kv.delete(user_id);
+
+    // Freeze should be a no-op, returning the same streak
+    const result = await db.UserFreezeStreak(user_id);
+    expect(result).not.toBeNull();
+    expect(result!.streak).toBe(3);
+
+    const row = await d1.prepare("SELECT current_streak, last_active_date FROM users WHERE id = ?")
+      .bind(user_id)
+      .first();
+    expect(row).not.toBeNull();
+    expect(row!.current_streak).toBe(3);
+    expect(row!.last_active_date).toBe(today);
+  });
+
+  it('UserFreezeStreak saves streak even after a gap day', async () => {
+    const house_id = (await db.HouseholdCreate("Freeze gap house"))?.id;
+    expect(house_id).not.toBeNull();
+    if (house_id == null) return;
+
+    const user_id = (await db.UserCreate("Jack", house_id))?.id;
+    expect(user_id).not.toBeNull();
+    if (user_id == null) return;
+
+    const today = Math.floor(getJulianDate());
+    const d1 = env.HONEYDEWSQL as D1Database;
+    const kv = env.HONEYDEW as KVNamespace;
+
+    // Simulate: user had a 4-day streak but last active 2 days ago (missed yesterday)
+    await d1.prepare("UPDATE users SET last_active_date = ?, current_streak = ? WHERE id = ?")
+      .bind(today - 2, 4, user_id)
+      .run();
+    await kv.delete(user_id);
+
+    // Freeze should still preserve the streak value (4) even though there's a gap
+    const result = await db.UserFreezeStreak(user_id);
+    expect(result).not.toBeNull();
+    expect(result!.streak).toBe(4);
+
+    const row = await d1.prepare("SELECT current_streak, last_active_date FROM users WHERE id = ?")
+      .bind(user_id)
+      .first();
+    expect(row).not.toBeNull();
+    expect(row!.current_streak).toBe(4);
+    expect(row!.last_active_date).toBe(today);
+  });
 });
 
 describe('Clothing tests', () => {

--- a/tests/telegram.test.ts
+++ b/tests/telegram.test.ts
@@ -246,6 +246,91 @@ describe('Telegram callback tests', () => {
     expect(removed_markup).toBe(true);
     expect(chore_done.lastDone).toBeGreaterThan(chore.lastDone);
   });
+
+  it('can handle an out-of-town callback and freeze streak', async () => {
+    let removed_markup = false;
+    let answer_text = "";
+    telegram.registerListener(async (x) => {
+      if (x.type == "POST" && x.method == "editMessageReplyMarkup") {
+        removed_markup = true;
+      }
+      if (x.type == "POST" && x.method == "answerCallbackQuery") {
+        answer_text = x.data.text || "";
+      }
+      return generateTelegramResponse(null);
+    });
+
+    const house_id = (await db.HouseholdCreate("Out of town house"))?.id;
+    expect(house_id).not.toBeNull();
+    if (house_id == null) return;
+
+    const user_id = (await db.UserCreate("Traveler", house_id))?.id;
+    expect(user_id).not.toBeNull();
+    if (user_id == null) return;
+
+    const timestamp = getJulianDate();
+    const chat_id = 5555555;
+    const tuser_id = 6666666;
+    expect(await db.UserRegisterTelegram(user_id, chat_id, tuser_id)).toBe(true);
+
+    // Give the user a streak
+    const today = Math.floor(getJulianDate());
+    const d1 = env.HONEYDEWSQL as D1Database;
+    await d1.prepare("UPDATE users SET last_active_date = ?, current_streak = ? WHERE id = ?")
+      .bind(today - 1, 5, user_id)
+      .run();
+    await kv.delete(user_id);
+
+    const chore = await db.ChoreCreate("Water plants", house_id, 1, 10);
+    expect(chore).not.toBeNull();
+    if (chore == null) return;
+
+    // Create an out-of-town callback
+    const callback = await db.TelegramCallbackCreate({
+      user_id,
+      type: "OUT_OF_TOWN",
+      chore_id: chore.id
+    });
+    expect(callback).not.toBeNull();
+    if (callback == null) return;
+
+    const query: TelegramCallbackQuery = {
+      id: "out-of-town-callback-id",
+      message: {
+        message_id: 99999,
+        chat: { id: chat_id, type: "private" },
+        date: timestamp,
+      },
+      from: { id: tuser_id, is_bot: false, first_name: "Traveler" },
+      chat_instance: "the chat instance",
+      data: callback,
+    };
+    const update1: TelegramUpdate = {
+      update_id: Math.floor(timestamp),
+      callback_query: query
+    };
+
+    const result = await HandleTelegramUpdate(db, update1);
+    expect(result.status).toEqual(200);
+    expect(removed_markup).toBe(true);
+
+    // Verify streak is frozen (5) and last_active_date is today
+    const row = await d1.prepare("SELECT current_streak, last_active_date FROM users WHERE id = ?")
+      .bind(user_id)
+      .first();
+    expect(row).not.toBeNull();
+    expect(row!.current_streak).toBe(5);
+    expect(row!.last_active_date).toBe(today);
+
+    // Verify the chore was NOT completed (lastDone should not change)
+    const chore_after = await db.ChoreGet(chore.id);
+    expect(chore_after).not.toBeNull();
+    expect(chore_after!.lastDone).toBe(chore.lastDone);
+
+    // Verify answer text mentions frozen streak
+    expect(answer_text).toContain("frozen");
+    expect(answer_text).toContain("5");
+  });
 });
 
 // Also stick the trigger stuff in here, because why not?
@@ -337,6 +422,58 @@ describe('Trigger tests', () => {
       await TriggerChores(db, i);
     }
   });
+  it('reminder includes out-of-town button when user has a streak', async () => {
+    let message_count = 0;
+    let has_out_of_town_button = false;
+    telegram.registerListener(async (x) => {
+      message_count += 1;
+      if (x.type == "POST" && x.method == "sendMessage" && x.data.reply_markup) {
+        const keyboard = x.data.reply_markup;
+        if (keyboard.inline_keyboard?.some((row: any[]) =>
+          row.some((btn: any) => btn.text === "I'm Out of Town")
+        )) {
+          has_out_of_town_button = true;
+        }
+      }
+      return generateTelegramResponse(null);
+    });
+
+    const house_id = (await db.HouseholdCreate("Streak reminder house"))?.id;
+    expect(house_id).not.toBeNull();
+    if (house_id == null) return;
+    expect(await db.HouseAutoAssignSetTime(house_id, 5)).toBe(true);
+
+    const user_id = (await db.UserCreate("Streaker", house_id))?.id;
+    expect(user_id).not.toBeNull();
+    if (user_id == null) return;
+
+    const chat_id = 7777777;
+    expect(await db.UserRegisterTelegram(user_id, chat_id, 8888888)).toBe(true);
+
+    // Give the user a streak
+    const today = Math.floor(getJulianDate());
+    const d1 = env.HONEYDEWSQL as D1Database;
+    await d1.prepare("UPDATE users SET last_active_date = ?, current_streak = ? WHERE id = ?")
+      .bind(today - 1, 3, user_id)
+      .run();
+    await kv.delete(user_id);
+
+    const chore = await db.ChoreCreate("Sweep floor", house_id, 1, 10);
+    expect(chore).not.toBeNull();
+    if (chore == null) return;
+
+    // Run assignment at hour 5
+    await TriggerChores(db, 5);
+    // message_count = 1 (assignment message)
+    const assignment_messages = message_count;
+
+    // Run reminder at hour 17 (5 + 12)
+    await TriggerChores(db, 17);
+    // Should have sent a reminder with the out-of-town button
+    expect(message_count).toBeGreaterThan(assignment_messages);
+    expect(has_out_of_town_button).toBe(true);
+  });
+
   it('no reminder when chores were not recently assigned', async () => {
     let message_count = 0;
     telegram.registerListener(async (x) => {


### PR DESCRIPTION
When a user has an active streak and receives a 12-hour chore reminder, the message now includes an "I'm Out of Town" button. Pressing it freezes the streak (updates last_active_date without incrementing the counter) and skips the current chore so it can be reassigned, preventing streak loss when users are traveling.

https://claude.ai/code/session_01USY8ofcxiZEuYatiabQaeL