### PR TITLE
Add Telegram notifications toggle (personal and household)

### DIFF
--- a/functions/api/routers/household.ts
+++ b/functions/api/routers/household.ts
@@ -85,6 +85,25 @@ const Router = router({
     const result = await db.HouseOutfitSetHour(user.household, hour);
     return result;
   }),
+  setTelegramNotifications: protectedProcedure.input(z.boolean()).query(async (ctx) => {
+
+    if (ctx.ctx.data.user == null) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        cause: "User was not found"
+      })
+    }
+    const user = ctx.ctx.data.user;
+    if (user.household == null) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        cause: "User does not have household assigned"
+      })
+    }
+    const db = ctx.ctx.data.db;
+    const result = await db.HouseholdSetTelegramNotifications(user.household, ctx.input);
+    return result;
+  }),
   setExpectingDate: protectedProcedure.input(DbHouseholdRawZ.pick({expecting:true})).query(async (ctx) => {
 
     if (ctx.ctx.data.user == null) {

--- a/functions/api/routers/me.ts
+++ b/functions/api/routers/me.ts
@@ -17,6 +17,18 @@ const Router = router({
     const result = await db.UserSetOutfitReminders(user.id, ctx.input);
     return result;
   }),
+  setTelegramNotifications: protectedProcedure.input(z.boolean()).query(async (ctx) => {
+    if (ctx.ctx.data.user == null) {
+      throw new TRPCError({
+        code: "UNAUTHORIZED",
+        cause: "User was not found"
+      })
+    }
+    const user = ctx.ctx.data.user;
+    const db = ctx.ctx.data.db;
+    const result = await db.UserSetTelegramNotifications(user.id, ctx.input);
+    return result;
+  }),
   magic_link: protectedProcedure.query(async (ctx)=> {
     if (ctx.ctx.data.user == null) {
       throw new TRPCError({
@@ -75,6 +87,7 @@ const Router = router({
       household,
       task: null,
       outfit_reminders: user.outfit_reminders,
+      telegram_notifications: user.telegram_notifications,
     };
     return AuthCheckZ.parse(result);
   }),

--- a/functions/auth/auth_types.ts
+++ b/functions/auth/auth_types.ts
@@ -28,6 +28,7 @@ export const AuthCheckZ = z.object({
     color: z.string().min(7),
     icon: z.string(),
     outfit_reminders: z.number().nonnegative().default(0),
+    telegram_notifications: z.number().nonnegative().default(1),
 }).strict()
 export type AuthCheck = z.infer<typeof AuthCheckZ>;
 

--- a/functions/auth/check.ts
+++ b/functions/auth/check.ts
@@ -29,6 +29,7 @@ export const onRequestGet: HoneydewPagesFunction = async function (context) {
         color: user.color,
         icon: user.icon,
         outfit_reminders: user.outfit_reminders ?? 0,
+        telegram_notifications: user.telegram_notifications ?? 1,
     }
 
     let result_json: string;

--- a/functions/database/_db.ts
+++ b/functions/database/_db.ts
@@ -221,6 +221,7 @@ export default class Database {
             last_active_date: null,
             current_streak: 0,
             outfit_reminders: 1,
+            telegram_notifications: 1,
         };
         const db_user = DbUserZ.parse(user);
         await this._db.insertInto("users").values(db_user).execute();
@@ -366,6 +367,20 @@ export default class Database {
         }
         catch (err) {
             console.error("UserSetOutfitReminders", err);
+            return false;
+        }
+    }
+
+    async UserSetTelegramNotifications(raw_user_id: UserId, enabled: boolean): Promise<boolean> {
+        try {
+            const user_id = UserIdZ.parse(raw_user_id);
+            if (await this.UserExists(user_id) == false) return false;
+            await this._db.updateTable("users").where("id", "==", user_id).set({ telegram_notifications: enabled ? 1 : 0 }).execute();
+            await this.CacheInvalidate(user_id);
+            return true;
+        }
+        catch (err) {
+            console.error("UserSetTelegramNotifications", err);
             return false;
         }
     }
@@ -524,10 +539,17 @@ export default class Database {
     async HouseholdTelegramMessageAllMembers(raw_id: HouseId, message: string, use_markdown: boolean = false, exclude_user?: UserId) {
         try {
             const id = HouseIdZ.parse(raw_id);
-            let query = this._db.selectFrom("users").select("_chat_id").where("household", "==", id);
+            // Only message members whose personal toggle is on AND whose household
+            // has telegram notifications enabled (both checked in a single query).
+            let query = this._db.selectFrom("users")
+                .innerJoin("households", "households.id", "users.household")
+                .select("users._chat_id")
+                .where("users.household", "==", id)
+                .where("users.telegram_notifications", "==", 1)
+                .where("households.telegram_notifications", "==", 1);
             if (exclude_user != undefined) {
                 const exclude_id = UserIdZ.parse(exclude_user);
-                query = query.where("id", "!=", exclude_id);
+                query = query.where("users.id", "!=", exclude_id);
             }
             const raw_results = await query.execute();
             if (raw_results == undefined) {
@@ -551,7 +573,16 @@ export default class Database {
     async HouseholdTelegramMessageOutfitMembers(raw_id: HouseId, message: string, use_markdown: boolean = false) {
         try {
             const id = HouseIdZ.parse(raw_id);
-            const raw_results = await this._db.selectFrom("users").select("_chat_id").where("household", "==", id).where("outfit_reminders", "==", 1).execute();
+            // Only message opted-in members whose personal telegram toggle is on AND
+            // whose household has telegram notifications enabled (single query).
+            const raw_results = await this._db.selectFrom("users")
+                .innerJoin("households", "households.id", "users.household")
+                .select("users._chat_id")
+                .where("users.household", "==", id)
+                .where("users.outfit_reminders", "==", 1)
+                .where("users.telegram_notifications", "==", 1)
+                .where("households.telegram_notifications", "==", 1)
+                .execute();
             if (raw_results == undefined) {
                 console.warn("HouseholdTelegramMessageOutfitMembers", `no members of ${raw_id} are opted in for outfit reminders`)
                 return true;
@@ -579,6 +610,7 @@ export default class Database {
                 id,
                 name,
                 expecting:null,
+                telegram_notifications: 1,
             };
             const house: DbHousehold = DbHouseholdZ.parse({
                 ...sql_house,
@@ -669,6 +701,27 @@ export default class Database {
             console.error("HouseExpectingSetDate", err);
             return false;
         }
+    }
+
+    async HouseholdSetTelegramNotifications(raw_id: HouseId, enabled: boolean): Promise<boolean> {
+        try {
+            const id = HouseIdZ.parse(raw_id);
+            if ((await this.HouseholdExists(id)) == false) return false;
+            await this._db.updateTable("households").where("id", "==", id).set({ telegram_notifications: enabled ? 1 : 0 }).executeTakeFirstOrThrow();
+            await this.CacheInvalidate(id);
+            return true;
+        }
+        catch (err) {
+            console.error("HouseholdSetTelegramNotifications", err);
+            return false;
+        }
+    }
+
+    // Returns true if the household has telegram notifications enabled (defaults to enabled if unset)
+    private async HouseholdTelegramEnabled(id: HouseId): Promise<boolean> {
+        const result = await this._db.selectFrom("households").select("telegram_notifications").where("id", "==", id).executeTakeFirst();
+        if (result == undefined) return false;
+        return result.telegram_notifications != 0;
     }
 
     async HouseAutoAssignSetTime(raw_id: HouseId, hour: number): Promise<boolean> {
@@ -810,7 +863,10 @@ export default class Database {
         try {
             if (timestamp == null) timestamp = (getJulianDate() - 0.5);
             const assignment_query = this._db.selectFrom("houseautoassign").where("choreAssignHour", "==", hour).where("choreLastAssignTime", "<", timestamp);
-            const joined_query = assignment_query.innerJoin("users", "users.household", "houseautoassign.house_id").select(["users._chat_id", "users.id", "houseautoassign.house_id as house_id"]);
+            const joined_query = assignment_query
+                .innerJoin("users", "users.household", "houseautoassign.house_id")
+                .innerJoin("households", "households.id", "houseautoassign.house_id")
+                .select(["users._chat_id", "users.id", "users.telegram_notifications as user_telegram_notifications", "households.telegram_notifications as house_telegram_notifications", "houseautoassign.house_id as house_id"]);
             const raw_results = await joined_query.execute();
             if (raw_results == undefined) return [];
             interface JoinedResults {
@@ -820,8 +876,11 @@ export default class Database {
             }
             const results = raw_results
                 .map((x) => {
+                    // Suppress the telegram notification (but still assign the chore)
+                    // when the user or their household has opted out of notifications.
+                    const notifications_enabled = x.user_telegram_notifications != 0 && x.house_telegram_notifications != 0;
                     return {
-                        chat_id: x._chat_id,
+                        chat_id: notifications_enabled ? x._chat_id : null,
                         house_id: HouseIdZ.safeParse(x.house_id),
                         user_id: UserIdZ.safeParse(x.id)
                     }
@@ -857,7 +916,10 @@ export default class Database {
         try {
             if (timestamp == null) timestamp = (getJulianDate() - 0.75);
             const assignment_query = this._db.selectFrom("houseautoassign").where("choreAssignHour", "==", hour).where("choreLastAssignTime", ">", timestamp);
-            const joined_query = assignment_query.innerJoin("users", "users.household", "houseautoassign.house_id").select(["users._chat_id", "users.id", "houseautoassign.house_id as house_id"]);
+            const joined_query = assignment_query
+                .innerJoin("users", "users.household", "houseautoassign.house_id")
+                .innerJoin("households", "households.id", "houseautoassign.house_id")
+                .select(["users._chat_id", "users.id", "users.telegram_notifications as user_telegram_notifications", "households.telegram_notifications as house_telegram_notifications", "houseautoassign.house_id as house_id"]);
             const raw_results = await joined_query.execute();
             if (raw_results == undefined) return [];
             interface JoinedResults {
@@ -867,8 +929,10 @@ export default class Database {
             }
             const results = raw_results
                 .map((x) => {
+                    // Suppress reminders for users (or households) that opted out of notifications
+                    const notifications_enabled = x.user_telegram_notifications != 0 && x.house_telegram_notifications != 0;
                     return {
-                        chat_id: x._chat_id,
+                        chat_id: notifications_enabled ? x._chat_id : null,
                         house_id: HouseIdZ.safeParse(x.house_id),
                         user_id: UserIdZ.safeParse(x.id)
                     }
@@ -1776,6 +1840,10 @@ export default class Database {
             const user_id = UserIdZ.parse(raw_user_id);
             const user = await this.UserGet(user_id);
             if (user == null) return null;
+            // Respect the user's personal telegram notifications toggle
+            if (user.telegram_notifications == 0) return false;
+            // Respect the household-wide telegram notifications toggle
+            if ((await this.HouseholdTelegramEnabled(user.household)) == false) return false;
             const telegram_id = user._chat_id;
             // TODO: figure out a better way to return error types
             if (telegram_id == null) return false;
@@ -2027,7 +2095,7 @@ export default class Database {
                 console.warn("HouseholdGetExtended: stale KV cache for", cache_key, "- invalidating");
                 await this.deleteKey(cache_key);
             }
-            const sql_household = await this._db.selectFrom("households").select("name").where("id", "==", id).executeTakeFirstOrThrow();
+            const sql_household = await this._db.selectFrom("households").select(["name", "telegram_notifications"]).where("id", "==", id).executeTakeFirstOrThrow();
             // next we need to query the database
             const members: DbHouseholdExtendedMemberRaw[] = [];
             const sql_members = await this._db.selectFrom("users").selectAll().where("household", "==", id).execute();
@@ -2060,6 +2128,7 @@ export default class Database {
                 current_project,
                 choreAssignHour: autoAssign?.choreAssignHour ?? null,
                 outfitHour: autoAssign?.outfitHour ?? null,
+                telegram_notifications: sql_household.telegram_notifications ?? 1,
             }
             const result = DbHouseholdExtendedZ.parse(extended_household);
             await this.CacheSet(cache_key, result);

--- a/functions/database/migration.ts
+++ b/functions/database/migration.ts
@@ -273,6 +273,25 @@ const HoneydewVersion12 = {
     }
 }
 
+const HoneydewVersion13 = {
+    async up(db: Kysely<any>): Promise<void> {
+        {
+            const table_name = "USERS"
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('telegram_notifications', "integer", (col)=>col.defaultTo(1).notNull()) // 1 = receive telegram notifications, 0 = opted out
+                .execute()
+        }
+        {
+            const table_name = "HOUSEHOLDS"
+            await db.schema
+                .alterTable(table_name)
+                .addColumn('telegram_notifications', "integer", (col)=>col.defaultTo(1).notNull()) // 1 = household telegram notifications enabled, 0 = disabled for everyone
+                .execute()
+        }
+    }
+}
+
 export const HoneydewMigrations: Migration[] = [
     HoneydewVersion1,
     HoneydewVersion2,
@@ -285,6 +304,7 @@ export const HoneydewMigrations: Migration[] = [
     HoneydewVersion9,
     HoneydewVersion10,
     HoneydewVersion11,
-    HoneydewVersion12
+    HoneydewVersion12,
+    HoneydewVersion13
 ]
 export const LatestHoneydewDBVersion = HoneydewMigrations.length;

--- a/functions/db_types.ts
+++ b/functions/db_types.ts
@@ -139,6 +139,7 @@ export const DbUserZRaw = z.object({
     last_active_date: z.number().nullable(), // Julian day number of last chore completion
     current_streak: z.number().nonnegative().default(0), // Current consecutive days streak
     outfit_reminders: z.number().nonnegative(), // 1 = opted in, 0 = opted out of outfit reminders
+    telegram_notifications: z.number().nonnegative().default(1), // 1 = receive telegram notifications, 0 = opted out
 })
 export const DbUserZ = DbUserZRaw.brand<"User">()
 export type DbUser = z.infer<typeof DbUserZ>;
@@ -150,6 +151,7 @@ export const DbHouseholdRawZ = z.object({
     name: z.string().max(255),
     members: z.array(UserIdZ),
     expecting: z.string().max(25).nullable(),
+    telegram_notifications: z.number().nonnegative().default(1), // 1 = household telegram notifications enabled, 0 = disabled for everyone
 })
 export const DbHouseholdZ = DbHouseholdRawZ.brand<"Household">();
 export type DbHouseholdRaw = z.infer<typeof DbHouseholdRawZ>;
@@ -270,6 +272,7 @@ export const DbHouseholdExtendedRawZ = z.object({
     members: z.array(DbHouseholdExtendedMemberRawZ),
     choreAssignHour: z.number().lt(24).nonnegative().nullable().default(null),
     outfitHour: z.number().lt(24).nonnegative().nullable().default(null),
+    telegram_notifications: z.number().nonnegative().default(1),
 });
 export const DbHouseholdExtendedZ = DbHouseholdExtendedRawZ.brand<"DbHouseholdExtended">()
 export type DbHouseholdExtendedRaw = z.infer<typeof DbHouseholdExtendedRawZ>;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -349,6 +349,36 @@ export const useUserStore = defineStore("user", {
                 return handleError(err);
             }
         },
+        async SetTelegramNotifications(enabled: boolean): APIResult<boolean> {
+            try {
+                const result = await client.me.setTelegramNotifications.query(enabled);
+                if (this._user != null) {
+                    this._user.telegram_notifications = enabled ? 1 : 0;
+                }
+                return {
+                    success: true,
+                    data: result
+                }
+            }
+            catch (err) {
+                return handleError(err);
+            }
+        },
+        async HouseholdSetTelegramNotifications(enabled: boolean): APIResult<boolean> {
+            try {
+                const result = await client.household.setTelegramNotifications.query(enabled);
+                if (this._user != null && this._user.household != null) {
+                    this._user.household.telegram_notifications = enabled ? 1 : 0;
+                }
+                return {
+                    success: true,
+                    data: result
+                }
+            }
+            catch (err) {
+                return handleError(err);
+            }
+        },
         async HouseholdSetOutfitHour(hour: number | null): APIResult<boolean> {
             try {
                 const result = await client.household.setOutfitHour.query(hour);

--- a/src/views/HouseholdView.vue
+++ b/src/views/HouseholdView.vue
@@ -66,6 +66,17 @@
             </label>
         </div>
         <div class="box block">
+            Telegram Notifications
+            <label class="checkbox is-block">
+                <input type="checkbox" v-model="household_telegram_enabled" @change="toggleHouseholdTelegram" />
+                Enable Telegram notifications for the whole household
+            </label>
+            <label class="checkbox is-block">
+                <input type="checkbox" v-model="telegram_opted_in" @change="toggleTelegramNotifications" />
+                Receive Telegram notifications for me
+            </label>
+        </div>
+        <div class="box block">
             Expecting? When did it start?
             <input class="input" type="date" :max="max_expecting_date" v-model="expecting_date" />
             <button class="button is-round" @click="setExpectingDate">Set Expecting Time</button>
@@ -93,6 +104,8 @@ export default defineComponent({
             autoassign_hour: 8,
             outfit_hour: "",
             outfit_opted_in: store._user != null ? store._user.outfit_reminders === 1 : true,
+            telegram_opted_in: store._user != null ? store._user.telegram_notifications === 1 : true,
+            household_telegram_enabled: store._user != null && store._user.household != null ? store._user.household.telegram_notifications === 1 : true,
             expecting_date: "",
             max_expecting_date: new Date().toISOString().split("T")[0],
         }
@@ -160,6 +173,22 @@ export default defineComponent({
             }
             else {
                 this.error = invite.message;
+            }
+        },
+        toggleTelegramNotifications: async function () {
+            this.error = "";
+            const result = await useUserStore().SetTelegramNotifications(this.telegram_opted_in);
+            if (result.success == false) {
+                this.error = result.message;
+                this.telegram_opted_in = !this.telegram_opted_in;
+            }
+        },
+        toggleHouseholdTelegram: async function () {
+            this.error = "";
+            const result = await useUserStore().HouseholdSetTelegramNotifications(this.household_telegram_enabled);
+            if (result.success == false) {
+                this.error = result.message;
+                this.household_telegram_enabled = !this.household_telegram_enabled;
             }
         },
         toggleOutfitReminders: async function () {


### PR DESCRIPTION
Adds the ability to enable or disable Telegram notifications at two levels:

- Personal: each user can opt out of receiving Telegram messages
  (`USERS.telegram_notifications`).
- Household: a household-wide switch that disables Telegram notifications
  for everyone in the household (`HOUSEHOLDS.telegram_notifications`).

Both default to enabled (migration v13). All Telegram broadcast paths now
respect both toggles:
- HouseholdTelegramMessageAllMembers / OutfitMembers filter recipients by
  the per-user flag and the household flag in a single joined query.
- TelegramMessageUser checks the user's flag and the household flag.
- Scheduled chore assignment/reminder queries suppress the Telegram message
  (chat_id nulled) when either toggle is off, while still assigning chores.

Exposes setTelegramNotifications procedures on the me and household routers,
surfaces the flags through the auth check payload, and adds UI toggles plus
store actions on the Household settings view.